### PR TITLE
[MCC-727815] Upgrade to allow for responses and response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.0.3
-Added ability to raise specify the response and response headers
+Added ability to specify the response body and response headers
 
 ## 0.0.2
 Ability to raise Faraday::SSLError

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.3
+Added ability to raise specify the response and response headers
+
 ## 0.0.2
 Ability to raise Faraday::SSLError
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ You must specify a dependency. If you want *all* external requests to fail, set 
 
 You can override the duration of the test by specifying `minutes=` with a number from 1 to 60.
 
+You can optionally specify the response body by setting `response=` and also the response header by setting `header=`. The endpoint to create a stubbed response uses query parameters, so your `response` and `header` fields must be URL encoded. For example, to return a response `{ "errors": "test_error" }`, you must send `response=%7B%20%22errors%22%3A%20%22test_error%22%20%7D`.
+
 You can also override the simulated response code, if your app is meant to handle different failures differently. `?dependency=google&failure=404` will simulate a 404 (Not Found) response instead of a 500 (Internal Server Error). `?dependency=google&failure=timeout` will pretend the server never responded at all (although it will raise an error instantly; the illusion is not perfect).
 
 **Sample calls and their effects:**
@@ -35,12 +37,22 @@ You can also override the simulated response code, if your app is meant to handl
 
 `https://myapp-sandbox.example.com/disable?dependency=google|yahoo&minutes=10&failure=timeout` For the next 10 minutes, all requests to urls containing 'google' and/or 'yahoo' will raise a Timeout error.
 
+`https://myapp-sandbox.example.com/disable?dependency=google|yahoo&minutes=10&failure=timeout&response=%7B%20%22errors%22%3A%20%22test_error%22%20%7D` Similar to the above example, except all external requests that match will now return `{ "errors": "test_error" }`.
+
+`https://myapp-sandbox.example.com/disable?dependency=google|yahoo&minutes=10&failure=timeout&response=%7B%20%22errors%22%3A%20%22test_error%22%20%7D&headers=%7B%20%22Content-Type%22%3A%20%22application%2Fjson%22%20%7D` Similar to the above example,except all external requests that match will now return `{ "errors": "test_error" }`, and will return the header `{ "Content-Type": "application/json" }`
+
 # Activating Aranea Programmatically
 
 From inside your application, you can run
 
 ```ruby
-Aranea::Failure.create(pattern: /google/, minutes: 5, failure: 503)
+Aranea::Failure.create(
+  pattern: /google/,
+  minutes: 5,
+  failure: 503,
+  response_hash: { "errors": "test_error" },
+  response_headers_hash: { "Content-Type": "application/json" }
+)
 ```
 
 All parameters are required in this form. They may alternatively be provided as strings ('google','5').

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can also override the simulated response code, if your app is meant to handl
 
 `https://myapp-sandbox.example.com/disable?dependency=google|yahoo&minutes=10&failure=timeout&response=%7B%20%22errors%22%3A%20%22test_error%22%20%7D` Similar to the above example, except all external requests that match will now return `{ "errors": "test_error" }`.
 
-`https://myapp-sandbox.example.com/disable?dependency=google|yahoo&minutes=10&failure=timeout&response=%7B%20%22errors%22%3A%20%22test_error%22%20%7D&headers=%7B%20%22Content-Type%22%3A%20%22application%2Fjson%22%20%7D` Similar to the above example,except all external requests that match will now return `{ "errors": "test_error" }`, and will return the header `{ "Content-Type": "application/json" }`
+`https://myapp-sandbox.example.com/disable?dependency=google|yahoo&minutes=10&failure=timeout&response=%7B%20%22errors%22%3A%20%22test_error%22%20%7D&headers=%7B%20%22Content-Type%22%3A%20%22application%2Fjson%22%20%7D` Similar to the above example, except all external requests that match will now return `{ "errors": "test_error" }`, and will return the header `{ "Content-Type": "application/json" }`
 
 # Activating Aranea Programmatically
 

--- a/lib/aranea/failure_repository.rb
+++ b/lib/aranea/failure_repository.rb
@@ -33,6 +33,8 @@ module Aranea
     def initialize(params)
       @pattern = Regexp.new(params[:pattern])
       @response = params[:failure]
+      @response_hash = params[:response_hash]
+      @response_headers_hash = params[:response_headers_hash]
     end
 
     def should_fail?(request_env, app)
@@ -45,7 +47,11 @@ module Aranea
       elsif @response == 'ssl_error'
         raise ::Faraday::SSLError, 'Fake failure from Aranea'
       else
-        ::Faraday::Response.new(status: @response.to_i, body: 'Fake failure from Aranea', response_headers: {})
+        ::Faraday::Response.new(
+          status: @response.to_i,
+          body: @response_hash.to_json,
+          response_headers: @response_headers_hash
+        )
       end
     end
 

--- a/lib/aranea/failure_repository.rb
+++ b/lib/aranea/failure_repository.rb
@@ -1,5 +1,7 @@
 require 'faraday'
 require 'active_support/core_ext/numeric/time'
+require 'json'
+
 module Aranea
   
   # TODO: Look into moving whitelisting of consumer hostnames to here and allowing it to be configurable via the consuming application

--- a/lib/aranea/failure_repository.rb
+++ b/lib/aranea/failure_repository.rb
@@ -33,8 +33,8 @@ module Aranea
     def initialize(params)
       @pattern = Regexp.new(params[:pattern])
       @response = params[:failure]
-      @response_hash = params[:response_hash]
-      @response_headers_hash = params[:response_headers_hash]
+      @response_hash = params[:response_hash] || {}
+      @response_headers_hash = params[:response_headers_hash] || {}
     end
 
     def should_fail?(request_env, app)

--- a/lib/aranea/version.rb
+++ b/lib/aranea/version.rb
@@ -1,5 +1,5 @@
 module Aranea
 
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 
 end

--- a/spec/faraday_middleware_spec.rb
+++ b/spec/faraday_middleware_spec.rb
@@ -21,9 +21,20 @@ describe Aranea::Faraday::FailureSimulator do
   end
 
   context 'a failure is active' do
+    let(:pattern) { 'yahoo|google' }
+    let(:failure) { 415 }
+    let(:minutes) { 100 }
+    let(:response_hash) { {'hello': 'there'} }
+    let(:response_headers_hash) { {'Content-type': 'application/json'} }
 
     before do
-      Aranea::Failure.create(pattern: 'yahoo|google', failure: '415', minutes: 100)
+      Aranea::Failure.create(
+        pattern: pattern,
+        failure: failure,
+        minutes: minutes,
+        response_hash: response_hash,
+        response_headers_hash: response_headers_hash
+      )
     end
 
     context 'the request does not match the specified pattern' do
@@ -52,8 +63,11 @@ describe Aranea::Faraday::FailureSimulator do
         described_class.new(@app).call(@env)
       end
 
-      it 'returns the specified response code' do
-        described_class.new(@app).call(@env).status.should eq(415)
+      it 'returns the specified response code, headers, and body' do
+        response = described_class.new(@app).call(@env)
+        response.status.should eq(415)
+        response.body.should eq(response_hash.to_json)
+        response.headers.should include(response_headers_hash)
       end
     end
 

--- a/spec/rack_middleware_spec.rb
+++ b/spec/rack_middleware_spec.rb
@@ -41,7 +41,7 @@ describe Aranea::Rack::FailureCreator do
     end
 
     it 'uses optional arguments when provided' do
-      @env['QUERY_STRING'] = 'dependency=example&minutes=10&failure=422'
+      @env['QUERY_STRING'] = 'dependency=example&minutes=10&failure=422&response=%7B%7D&headers=%7B%7D'
       status, headers, response = described_class.new(@app).call(@env).flatten.to_a
       expect(response).to eq("For the next 10 minutes, all requests to urls containing 'example' will 422")
     end


### PR DESCRIPTION
This PR adds support to the Aranea gem to stub out response bodies and response headers.

See more info in the README.MD.

Quick summary:
- Added support for specifying the response body via URL encoded query parameter
- Added support for specifying the response header via URL encoded query parameter
Example:
`https://plinth-sandbox.imedidata.net/disable?dependency=topics&failure=500&minutes=2&response=%7B%22errors%22%3A+%22helloteam42%22%7D&headers=%7B%22Content-type%22%3A+%22application%2Fjson%22%7D`

When a request URI matches /topics/
The response would:
Return 500
Return a body with `{ "errors": "helloteam42" }`
Return a header with key `Content-type`, value `application/json`